### PR TITLE
v1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,38 @@
-**/*.terraform*
-**/*.tfstate*
+# Local .terraform directories
+**/.terraform/*
 **/*.dev*
 
+# .tfstate files
+**/*.tfstate
+**/*.tfstate.*
+**/*.terraform.lock.hcl
+
+# Crash log files
 crash.log
 
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+#
+**/*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
 override.tf
 override.tf.json
 *_override.tf
 *_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+**/.terraformrc
+**/terraform.rc
+
+.DS_Store

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,8 @@
+formatter: ""
+output:
+  file: README.md
+settings:
+  hide-empty: true
+sort:
+  enabled: true
+  by: name

--- a/README.md
+++ b/README.md
@@ -1,21 +1,19 @@
 # terraform-aws-route53-hosted-zone
 A terraform module for an AWS Route53 hosted zone, with associated records, VPC attachments, and DNSSEC configurations
 
-# Terraform Docs
-
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~>1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.6 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-
-## Modules
-
-No modules.
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.6 |
 
 ## Resources
 
@@ -28,6 +26,7 @@ No modules.
 | [aws_route53_record.record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_vpc_association_authorization.auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_vpc_association_authorization) | resource |
 | [aws_route53_zone.zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
+| [aws_route53_zone.zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 
 ## Inputs
 
@@ -39,9 +38,10 @@ No modules.
 | <a name="input_delegation_set_id"></a> [delegation\_set\_id](#input\_delegation\_set\_id) | A delegation set whose NS records you want to assign to the hosted zone | `string` | `null` | no |
 | <a name="input_dnssec"></a> [dnssec](#input\_dnssec) | Configuration to enable DNSSEC for this hosted zone. If a KMS key is provided, it will be used. Otherwise, one will be created | <pre>object({<br>    enabled        = bool<br>    kms_key        = optional(string)<br>    signing_status = optional(string)<br>  })</pre> | <pre>{<br>  "enabled": false,<br>  "kms_key": null,<br>  "signing_status": null<br>}</pre> | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Whether or not to forcibly delete all records in the zone when the zone is deleted | `bool` | `true` | no |
-| <a name="input_name"></a> [name](#input\_name) | The name of the hosted zone | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | The name of the hosted zone. Required if not using var.use\_zone | `string` | `null` | no |
 | <a name="input_records"></a> [records](#input\_records) | DNS records to create within the hosted zone | <pre>list(object({<br>    name            = string<br>    type            = string<br>    ttl             = optional(number)<br>    records         = optional(list(string))<br>    set_identifier  = optional(string)<br>    health_check_id = optional(string)<br>    alias = optional(object({<br>      name                   = string<br>      zone_id                = string<br>      evaluate_target_health = optional(bool)<br>    }))<br>    failover_routing_policy = optional(object({<br>      type = string<br>    }))<br>    geolocation_routing_policy = optional(object({<br>      continent   = string<br>      country     = string<br>      subdivision = optional(string)<br>    }))<br>    latency_routing_policy = optional(object({<br>      region = string<br>    }))<br>    weighted_routing_policy = optional(object({<br>      weight = number<br>    }))<br>    multivalue_answer_routing_policy = optional(bool)<br>    allow_overwrite                  = optional(bool)<br>  }))</pre> | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to assign to the hosted zone | `map(string)` | `{}` | no |
+| <a name="input_use_zone"></a> [use\_zone](#input\_use\_zone) | Manage records within an existing hosted zone instead of creating a new one | <pre>object({<br>    name    = optional(string)<br>    id      = optional(string)<br>    private = optional(bool)<br>  })</pre> | `{}` | no |
 
 ## Outputs
 
@@ -59,4 +59,5 @@ No modules.
 | <a name="output_name"></a> [name](#output\_name) | The provided value for var.name |
 | <a name="output_records"></a> [records](#output\_records) | Records created in this hosted zone |
 | <a name="output_tags"></a> [tags](#output\_tags) | Tags assigned to the hosted zone |
-| <a name="output_zone"></a> [zone](#output\_zone) | The hosted zone object itself |
+| <a name="output_zone"></a> [zone](#output\_zone) | The hosted zone object created by the module |
+<!-- END_TF_DOCS -->

--- a/_config.tf
+++ b/_config.tf
@@ -1,8 +1,0 @@
-terraform {
-  experiments = [module_variable_optional_attrs]
-  required_providers {
-    aws = {
-      source = "hashicorp/aws"
-    }
-  }
-}

--- a/_data.tf
+++ b/_data.tf
@@ -1,0 +1,7 @@
+data "aws_route53_zone" "zone" {
+  count = local.create_zone ? 0 : 1
+
+  name         = var.use_zone.name
+  zone_id      = var.use_zone.id
+  private_zone = coalesce(var.use_zone.private, false)
+}

--- a/_out.tf
+++ b/_out.tf
@@ -20,22 +20,22 @@ output "delegation_set_id" {
 
 output "dnssec" {
   description = "The dnssec object created by this module, if enabled"
-  value       = var.dnssec.enabled ? aws_route53_hosted_zone_dnssec.dnssec.0 : null
+  value       = local.dnssec_enabled ? aws_route53_hosted_zone_dnssec.dnssec[0] : null
 }
 
 output "dnssec_key_signing_key" {
   description = "If enabled, the key signing key for dnssec for this hosted zone"
-  value       = var.dnssec.enabled ? aws_route53_key_signing_key.dnssec.0 : null
+  value       = local.dnssec_enabled ? aws_route53_key_signing_key.dnssec[0] : null
 }
 
 output "dnssec_kms_alias" {
   description = "The alias for the key created to implement dnssec for this hosted zone, if a key was not provided"
-  value       = !(var.dnssec.enabled && var.dnssec.kms_key == null) ? null : aws_kms_alias.dnssec.0
+  value       = local.dnssec_enabled && var.dnssec.kms_key == null ? aws_kms_alias.dnssec[0] : null
 }
 
 output "dnssec_kms_key" {
   description = "The key created to implement dnssec for this hosted zone, if one was not provided"
-  value       = !(var.dnssec.enabled && var.dnssec.kms_key == null) ? null : aws_kms_key.dnssec.0
+  value       = local.dnssec_enabled && var.dnssec.kms_key == null ? aws_kms_key.dnssec[0] : null
 }
 
 output "force_destroy" {
@@ -61,6 +61,6 @@ output "tags" {
 }
 
 output "zone" {
-  description = "The hosted zone object itself"
-  value       = aws_route53_zone.zone
+  description = "The hosted zone object created by the module"
+  value       = local.create_zone ? aws_route53_zone.zone : null
 }

--- a/_var.tf
+++ b/_var.tf
@@ -49,8 +49,9 @@ variable "force_destroy" {
 }
 
 variable "name" {
-  description = "The name of the hosted zone"
+  description = "The name of the hosted zone. Required if not using var.use_zone"
   type        = string
+  default     = null
 }
 
 variable "records" {
@@ -91,4 +92,14 @@ variable "tags" {
   description = "Tags to assign to the hosted zone"
   type        = map(string)
   default     = {}
+}
+
+variable "use_zone" {
+  description = "Manage records within an existing hosted zone instead of creating a new one"
+  type = object({
+    name    = optional(string)
+    id      = optional(string)
+    private = optional(bool)
+  })
+  default = {}
 }

--- a/_versions.tf
+++ b/_versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = "~>1.0"
+  required_version = "~>1.3"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.6"
+      version = "~> 3.6"
     }
   }
 }

--- a/_versions.tf
+++ b/_versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "~>1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.6"
+    }
+  }
+}

--- a/dnssec.tf
+++ b/dnssec.tf
@@ -1,5 +1,5 @@
 resource "aws_kms_key" "dnssec" {
-  count = var.dnssec.enabled && var.dnssec.kms_key == null ? 1 : 0
+  count = local.dnssec_enabled && var.dnssec.kms_key == null ? 1 : 0
 
   customer_master_key_spec = "ECC_NIST_P256"
   deletion_window_in_days  = 7
@@ -48,23 +48,23 @@ resource "aws_kms_key" "dnssec" {
 }
 
 resource "aws_kms_alias" "dnssec" {
-  count = var.dnssec.enabled && var.dnssec.kms_key == null ? 1 : 0
+  count = local.dnssec_enabled && var.dnssec.kms_key == null ? 1 : 0
 
   name          = replace("alias/dnssec-${var.name}", ".", "-")
   target_key_id = aws_kms_key.dnssec.0.arn
 }
 
 resource "aws_route53_key_signing_key" "dnssec" {
-  count = var.dnssec.enabled ? 1 : 0
+  count = local.dnssec_enabled ? 1 : 0
 
-  hosted_zone_id             = aws_route53_zone.zone.id
+  hosted_zone_id             = aws_route53_zone.zone[0].id
   key_management_service_arn = var.dnssec.kms_key != null ? var.dnssec.kms_key : aws_kms_key.dnssec.0.arn
   name                       = var.name
 }
 
 resource "aws_route53_hosted_zone_dnssec" "dnssec" {
-  count = var.dnssec.enabled ? 1 : 0
+  count = local.dnssec_enabled ? 1 : 0
 
-  hosted_zone_id = aws_route53_zone.zone.id
+  hosted_zone_id = aws_route53_zone.zone[0].id
   signing_status = var.dnssec.signing_status
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,5 +1,5 @@
 module "my_hosted_zone" {
-  source = "../"
+  source = "../../"
 
   name = "example.com"
 

--- a/records.tf
+++ b/records.tf
@@ -1,31 +1,3 @@
-resource "aws_route53_zone" "zone" {
-  comment           = var.comment
-  delegation_set_id = var.delegation_set_id
-  force_destroy     = var.force_destroy
-  name              = var.name
-
-  dynamic "vpc" {
-    for_each = { for vpc in var.associated_vpcs : vpc.vpc_id => vpc }
-
-    content {
-      vpc_id     = vpc.value.vpc_id
-      vpc_region = vpc.value.vpc_region
-    }
-  }
-
-  tags = merge(var.tags, {
-    "Managed By Terraform" = "true"
-  })
-}
-
-resource "aws_route53_vpc_association_authorization" "auth" {
-  for_each = { for auth in var.authorized_vpc_associations : auth.vpc_id => auth }
-
-  vpc_id     = each.value.vpc_id
-  vpc_region = each.value.vpc_region
-  zone_id    = aws_route53_zone.zone.id
-}
-
 resource "aws_route53_record" "record" {
   for_each = {
     for record in var.records : join("-",
@@ -33,7 +5,11 @@ resource "aws_route53_record" "record" {
     ) => record
   }
 
-  zone_id                          = aws_route53_zone.zone.id
+  zone_id = coalesce(
+    try(data.aws_route53_zone.zone[0].id, null),
+    try(aws_route53_zone.zone[0].id, null)
+  )
+
   name                             = each.value.name
   type                             = each.value.type
   ttl                              = each.value.ttl

--- a/zone.tf
+++ b/zone.tf
@@ -1,0 +1,34 @@
+locals {
+  create_zone    = var.use_zone.id == null && var.use_zone.name == null
+  dnssec_enabled = local.create_zone && var.dnssec.enabled
+}
+
+resource "aws_route53_zone" "zone" {
+  count = local.create_zone ? 1 : 0
+
+  comment           = var.comment
+  delegation_set_id = var.delegation_set_id
+  force_destroy     = var.force_destroy
+  name              = var.name
+
+  dynamic "vpc" {
+    for_each = { for vpc in var.associated_vpcs : vpc.vpc_id => vpc }
+
+    content {
+      vpc_id     = vpc.value.vpc_id
+      vpc_region = vpc.value.vpc_region
+    }
+  }
+
+  tags = merge(var.tags, {
+    "Managed By Terraform" = "true"
+  })
+}
+
+resource "aws_route53_vpc_association_authorization" "auth" {
+  for_each = local.create_zone ? { for auth in var.authorized_vpc_associations : auth.vpc_id => auth } : {}
+
+  vpc_id     = each.value.vpc_id
+  vpc_region = each.value.vpc_region
+  zone_id    = aws_route53_zone.zone[0].id
+}


### PR DESCRIPTION
- Add `var.use_zone` so the module can be used to manage records within existing zones
- adjust `.gitignore` for some dev files
- Add `.terraform-docs.yml` for workflow
- Rename `_config.tf` to `_versions.tf` so it fits the conventions I'm seeing in other modules, but is still floated above resources in vscode
- Separate `main.tf` into `zone.tf` and `records.tf` for the sake of organizing
- Move `examples/*` stuff to `examples/basic/*` for Terraform Cloud UI integration