### PR TITLE
v1.1.1

### DIFF
--- a/_out.tf
+++ b/_out.tf
@@ -62,5 +62,5 @@ output "tags" {
 
 output "zone" {
   description = "The hosted zone object created by the module"
-  value       = local.create_zone ? aws_route53_zone.zone : null
+  value       = local.create_zone ? one(aws_route53_zone.zone) : null
 }


### PR DESCRIPTION
- fix `zone` output (broke in v1.1.0 because `aws_route53_zone.zone` is now a tuple with one element)